### PR TITLE
remove world parameter requirement from Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@ A Typescript/Javascript wrapper around the OnAir Airline Manager's API.
 ```javascript
 import OnAirApi from 'onair-api'
 
-// define the prerequisite keys, and world
+// define the prerequisite keys
 // apiKey and companyId can be found in the lower left corner of the options screen within the OnAir Desktop client
 const apikey = 'YOUR-API-KEY'
-const world = 'cumulus' // one of, cumulus, stratus, thunder. Use 'stratus' for clear-sky world
 const companyId = 'YOUR-COMPANY-ID'
 
 // instantiate the OnAirApi
-const Api = new OnAirApi({ apiKey, world, companyId });
+const Api = new OnAirApi({ apiKey, companyId });
 
 /**
  * call one of the Api methods, like getCompany
@@ -60,7 +59,7 @@ let company = await Api.getCompany();
 - [getEmployee](#getemployeeemployeeid-string)
 
 ### getCompany()
-Fetches the company details for the given companyId, and world.
+Fetches the company details for the given companyId.
 #### Usage
 ```typescript
 import OnAirApi, { Company, OnAirApiConfig, } from 'onair-api'
@@ -68,7 +67,6 @@ import OnAirApi, { Company, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -82,7 +80,7 @@ let companyDetails: Company = await api.getCompany();
 
 
 ### getCompanyFbos()
-Fetches the FBOs for a given companyId, and world.
+Fetches the FBOs for a given companyId.
 #### Usage
 ```typescript
 import OnAirApi, { Fbo, OnAirApiConfig, } from 'onair-api'
@@ -90,7 +88,6 @@ import OnAirApi, { Fbo, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -104,7 +101,7 @@ let companyFbos: Fbo[] = await api.getCompanyFbos();
 
 
 ### getCompanyFleet()
-Fetches the aircraft that are owned, leased, or rented for a given companyId, and world.
+Fetches the aircraft that are owned, leased, or rented for a given companyId.
 
 #### Usage
 ```typescript
@@ -112,7 +109,6 @@ import OnAirApi, { Aircraft, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -125,7 +121,7 @@ let companyFleet: Aircraft[] = await api.getCompanyFleet();
 
 
 ### getCompanyFlights()
-Fetches the Flights for a given companyId, and world.
+Fetches the Flights for a given companyId.
 
 #### Usage
 ```typescript
@@ -134,7 +130,6 @@ import OnAirApi, { Flight, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -147,7 +142,7 @@ let companyFlights: Flight[] = await api.getCompanyFlights();
  - [getCompanyFlights.md](docs/responses/getCompanyFlights.md)
 
 ### getCompanyJobs(completed = false)
-Fetches the pending jobs for a given companyId, and world.
+Fetches the pending jobs for a given companyId.
 Pass `true` as the first argument to return completed jobs.
 
 #### Usage
@@ -156,7 +151,6 @@ import OnAirApi, { Job, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -172,7 +166,7 @@ let completedCompanyJobs: Job[] = await api.getCompanyJobs(true);
  - [getCompanyJobs.md](docs/responses/getCompanyJobs.md)
 
 ### getCompanyEmployees()
-Fetches the Persons currently employed by a given companyId and world.
+Fetches the Persons currently employed by a given companyId.
 #### Usage
 ```typescript
 import OnAirApi, { People, OnAirApiConfig, } from 'onair-api'
@@ -180,7 +174,6 @@ import OnAirApi, { People, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -193,14 +186,13 @@ let companyEmployees: People[] = await api.getCompanyEmployees();
  - [getCompanyEmployees.md](docs/responses/getCompanyEmployees.md)
 
 ### getCompanyCashFlow()
-Fetches the cash flow for a given companyId and world.
+Fetches the cash flow for a given companyId.
 #### Usage
 ```typescript
 import OnAirApi, { CashFlow, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -216,7 +208,7 @@ let companyCashFlow: CashFlow[] = await api.getCompanyCashFlow();
 ---
 
 ### getCompanyIncomeStatement(startDate: string, endDate: string)
-Fetches the income statement within a given range for a companyId and world.
+Fetches the income statement within a given range for a companyId.
 If no startDate or endDate is provided it will return the last 30 days.
 
 #### Usage
@@ -225,7 +217,6 @@ import OnAirApi, { IncomeStatement, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -253,7 +244,6 @@ import OnAirApi, { BalanceSheet, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -267,7 +257,7 @@ let balancesheet: BalanceSheet = await api.getCompanyBalanceSheet();
 
 
 ### getAircraft(aircraftId: string)
-Fetches the Aircraft details for a given aircraftId and world.
+Fetches the Aircraft details for a given aircraftId.
 
 #### Usage
 ```typescript
@@ -275,7 +265,6 @@ import OnAirApi, { Aircraft, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -298,7 +287,6 @@ import OnAirApi, { Flight, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -312,7 +300,7 @@ let companyAircraftFlights: Flight[] = await api.getAircraftFlights(aircraftId);
  - [getAircraftFlights.md](docs/responses/getAircraftFlights.md)
 
 ### getAirport(airportCode: string)
-Fetches Airport details for a given airport Code and world.
+Fetches Airport details for a given airport Code.
 
 #### Usage
 ```typescript
@@ -320,7 +308,6 @@ import OnAirApi, { Airport, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -335,7 +322,7 @@ let airport: Airport = await api.getAirport(airportCode);
 
 
 ### getFlight(flightId: string)
-Fetches Flight details for a given flightId and world.
+Fetches Flight details for a given flightId.
 
 #### Usage
 ```typescript
@@ -343,7 +330,6 @@ import OnAirApi, { Flight, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -357,7 +343,7 @@ let flight: Flight = await api.getFlight(flightId);
  - [getFlight.md](docs/responses/getFlight.md)
 
 ### getVirtualAirline()
-Fetches VirtualAirline details for a given vaId, and world. Note: this requires the vaId to be provided during Api instantiation
+Fetches VirtualAirline details for a given vaId. Note: this requires the vaId to be provided during Api instantiation
 
 #### Usage
 ```typescript
@@ -365,7 +351,6 @@ import OnAirApi, { VirtualAirline, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -379,7 +364,7 @@ let va: VirtualAirline = await api.getVirtualAirline();
 
 
 ### getVirtualAirlineMembers()
-Fetches the members of a Virtual Airline for a given vaId, and world.
+Fetches the members of a Virtual Airline for a given vaId.
 
 #### Usage
 ```typescript
@@ -387,7 +372,6 @@ import OnAirApi, { Member, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -399,7 +383,7 @@ let vaMembers: Member[] = await api.getVirtualAirlineMembers();
   - [getVirtualAirlineMembers.md](docs/responses/getVirtualAirlineMembers.md)
 
 ### getVirtualAirlineShareHolders()
-Fetches the ShareHolders of a Virtual Airline for a given vaId, and world.
+Fetches the ShareHolders of a Virtual Airline for a given vaId.
 
 #### Usage
 ```typescript
@@ -407,7 +391,6 @@ import OnAirApi, { ShareHolder, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -419,7 +402,7 @@ let vaShareHolders: ShareHolder[] = await api.getVirtualAirlineShareHolders();
 #### Example Response
  - [getVirtualAirlineShareHolders.md](docs/responses/getVirtualAirlineShareHolders.md)
 ### getVirtualAirlineRoles()
-Fetches the Roles for a given vaId and world.
+Fetches the Roles for a given vaId.
 
 #### Usage
 ```typescript
@@ -427,7 +410,6 @@ import OnAirApi, { VARole, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -440,7 +422,7 @@ let roles: VARole[] = await api.getVirtualAirlineRoles();
  - [getVirtualAirlineRoles.md](docs/responses/getVirtualAirlineRoles.md)
 
 ### getEmployee(employeeId: string)
-Fetches details for a given employeeId and world.
+Fetches details for a given employeeId.
 
 #### Usage
 ```typescript
@@ -448,7 +430,6 @@ import OnAirApi, { People, OnAirApiConfig, } from 'onair-api'
 
 const apiConfig: OnAirApiConfig = {
   apiKey: 'YOUR-API-KEY',
-  world: 'cumulus',
   companyId: 'YOUR-COMPANY-ID',
   vaId: 'YOUR-VA-ID'
 };
@@ -478,9 +459,9 @@ import { OnAirApi, } from 'onair-api'
 (async function () {
     const apiKey = process.env.COMPANY_APIKEY;
     const companyId = process.env.COMPANY_ID;
-    const world = process.env.COMPANY_WORLD;
+    const vaId = process.env.VIRTUAL_AIRLINE_ID;
 
-    const Api = new OnAirApi({ apiKey, companyId, world });
+    const Api = new OnAirApi({ apiKey, companyId, vaId, });
 
     let company = await Api.getCompanyDetails();
     let fleet = await Api.getCompanyFleet();
@@ -501,9 +482,9 @@ import { Company, Aircraft, Api, } from 'onair-api/src/types'
 (async function () {
     const apiKey: string = process.env.COMPANY_APIKEY;
     const companyId: string = process.env.COMPANY_ID;
-    const world: string = process.env.COMPANY_WORLD;
+    const vaId = process.env.VIRTUAL_AIRLINE_ID;
 
-    const api = new OnAirApi({ apiKey, companyId, world });
+    const api: Api = new OnAirApi({ apiKey, companyId, vaId, });
 
     let company: Company = await api.getCompanyDetails();
     let fleet: Aircraft[] = await api.getCompanyFleet();

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -3,11 +3,11 @@ declare global {
       interface ProcessEnv {
         COMPANY_APIKEY: string;
         COMPANY_ID: string;
-        COMPANY_WORLD: string;
+        VIRTUAL_AIRLINE_ID: string;
       }
     }
-  }
-  
+}
+
 // If this file has no import/export statements (i.e. is a script)
 // convert it into a module by adding an empty export statement.
-export {}
+export { };

--- a/src/api/getAircraft.ts
+++ b/src/api/getAircraft.ts
@@ -4,7 +4,7 @@ import { uuid4 } from '../utils';
 
 const endPoint = 'aircraft/';
 
-export const getAircraft = async (aircraftId: string, apiKey: string, world: string): Promise<Aircraft> => {
+export const getAircraft = async (aircraftId: string, apiKey: string): Promise<Aircraft> => {
     if (!aircraftId.match(uuid4) ) {
         throw new Error('Aircraft ID is incorrect! It should be a 36 character UUID');
     }

--- a/src/api/getAircraftFlights.ts
+++ b/src/api/getAircraftFlights.ts
@@ -4,7 +4,7 @@ import { uuid4 } from '../utils';
 
 const endPoint = 'aircraft/';
 
-export const getAircraftFlights = async (aircraftId: string, apiKey: string, world: string, page = 1, limit = 10): Promise<Flight[]> => {
+export const getAircraftFlights = async (aircraftId: string, apiKey: string, page = 1, limit = 10): Promise<Flight[]> => {
     if (!aircraftId.match(uuid4)) {
         throw new Error('Aircraft ID is incorrect! It should be a 36 character UUID');
     }

--- a/src/api/getAirport.ts
+++ b/src/api/getAirport.ts
@@ -3,7 +3,7 @@ import onAirRequest, { AirportResponse } from './onAirRequest';
 
 const endPoint = 'airports/';
 
-export const getAirport = async (icao: string, apiKey: string, world: string) => {
+export const getAirport = async (icao: string, apiKey: string) => {
     try {
         const response = await onAirRequest<AirportResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${icao}`,

--- a/src/api/getCompany.ts
+++ b/src/api/getCompany.ts
@@ -3,7 +3,7 @@ import onAirRequest, { CompanyResponse } from './onAirRequest';
 
 const endPoint = 'company/';
 
-export const getCompany = async (companyId: string, apiKey: string, world: string) => {
+export const getCompany = async (companyId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<CompanyResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${companyId}`,

--- a/src/api/getCompanyBalanceSheet.ts
+++ b/src/api/getCompanyBalanceSheet.ts
@@ -3,7 +3,7 @@ import onAirRequest, { BalanceSheetResponse } from './onAirRequest';
 
 const endPoint = 'company/';
 
-export const getCompanyBalanceSheet = async (companyId: string, apiKey: string, world: string) => {
+export const getCompanyBalanceSheet = async (companyId: string, apiKey: string) => {
 
     try {
         const response = await onAirRequest<BalanceSheetResponse>(

--- a/src/api/getCompanyCashFlow.ts
+++ b/src/api/getCompanyCashFlow.ts
@@ -3,7 +3,7 @@ import onAirRequest, { CashFlowResponse } from './onAirRequest';
 
 const endPoint = 'company/';
 
-export const getCompanyCashFlow = async (companyId: string, apiKey: string, world: string) => {
+export const getCompanyCashFlow = async (companyId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<CashFlowResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${companyId}/cashflow`,

--- a/src/api/getCompanyEmployees.ts
+++ b/src/api/getCompanyEmployees.ts
@@ -3,7 +3,7 @@ import onAirRequest, { PeopleResponse } from './onAirRequest';
 
 const endPoint = 'company/';
 
-export const getCompanyEmployees = async (companyId: string, apiKey: string, world: string) => {
+export const getCompanyEmployees = async (companyId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<PeopleResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${companyId}/employees`,

--- a/src/api/getCompanyFbos.ts
+++ b/src/api/getCompanyFbos.ts
@@ -3,7 +3,7 @@ import onAirRequest, { FboResponse } from './onAirRequest';
 
 const endPoint = 'company/';
 
-export const getCompanyFbos = async (companyId: string, apiKey: string, world: string) => {
+export const getCompanyFbos = async (companyId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<FboResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${companyId}/fbos`,

--- a/src/api/getCompanyFleet.ts
+++ b/src/api/getCompanyFleet.ts
@@ -3,7 +3,7 @@ import onAirRequest, { AircraftResponse } from './onAirRequest';
 
 const endPoint = 'company/';
 
-export const getCompanyFleet = async (companyId: string, apiKey: string, world: string) => {
+export const getCompanyFleet = async (companyId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<AircraftResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${companyId}/fleet`,

--- a/src/api/getCompanyFlights.ts
+++ b/src/api/getCompanyFlights.ts
@@ -3,7 +3,7 @@ import onAirRequest, { FlightResponse } from './onAirRequest';
 
 const endPoint = 'company/';
 
-export const getCompanyFlights = async (companyId: string, apiKey: string, world: string, page=1, limit=10) => {
+export const getCompanyFlights = async (companyId: string, apiKey: string, page=1, limit=10) => {
     const startIndex = page > 1 ? limit * page : 0;
 
     try {

--- a/src/api/getCompanyIncomeStatement.ts
+++ b/src/api/getCompanyIncomeStatement.ts
@@ -3,7 +3,7 @@ import onAirRequest, { IncomeStatementResponse } from './onAirRequest';
 
 const endPoint = 'company/';
 
-export const getCompanyIncomeStatement = async (startDate: string, endDate: string, companyId: string, apiKey: string, world: string) => {
+export const getCompanyIncomeStatement = async (startDate: string, endDate: string, companyId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<IncomeStatementResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${companyId}/incomestatement?startDate=${startDate}&endDate=${endDate}`,

--- a/src/api/getCompanyJobs.ts
+++ b/src/api/getCompanyJobs.ts
@@ -2,7 +2,7 @@ import { Job, } from '../types';
 import onAirRequest, { JobResponse } from './onAirRequest';
 
 
-export const getCompanyJobs = async (companyId: string, apiKey: string, world: string, completed = false) => {
+export const getCompanyJobs = async (companyId: string, apiKey: string, completed = false) => {
 
     try {
         const response = await onAirRequest<JobResponse>(

--- a/src/api/getEmployee.ts
+++ b/src/api/getEmployee.ts
@@ -2,7 +2,7 @@ import onAirRequest, { PeopleResponse } from './onAirRequest';
 import { People } from '../types';
 import { uuid4 } from '../utils';
 
-export const getEmployee = async (employeeId: string, apiKey: string, world: string): Promise<People> => {
+export const getEmployee = async (employeeId: string, apiKey: string): Promise<People> => {
     if (!uuid4.test(employeeId) ) {
         throw new Error('People ID is incorrect! It should be a 36 character UUID');
     }

--- a/src/api/getFlight.ts
+++ b/src/api/getFlight.ts
@@ -2,7 +2,7 @@ import onAirRequest, { FlightResponse } from './onAirRequest';
 import { Flight } from '../types';
 import { uuid4 } from '../utils';
 
-export const getFlight = async (flightId: string, apiKey: string, world: string): Promise<Flight> => {
+export const getFlight = async (flightId: string, apiKey: string): Promise<Flight> => {
     if (!uuid4.test(flightId) ) {
         throw new Error('Flight ID is incorrect! It should be a 36 character UUID');
     }

--- a/src/api/getVirtualAirline.ts
+++ b/src/api/getVirtualAirline.ts
@@ -3,7 +3,7 @@ import onAirRequest, { VirtualAirlineResponse } from './onAirRequest';
 
 const endPoint = 'va/';
 
-export const getVirtualAirline = async (vaId: string, apiKey: string, world: string) => {
+export const getVirtualAirline = async (vaId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<VirtualAirlineResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${vaId}`,

--- a/src/api/getVirtualAirlineMembers.ts
+++ b/src/api/getVirtualAirlineMembers.ts
@@ -3,7 +3,7 @@ import onAirRequest, { VirtualAirlineMemberResponse } from './onAirRequest';
 
 const endPoint = 'va/';
 
-export const getVirtualAirlineMembers = async (vaId: string, apiKey: string, world: string) => {
+export const getVirtualAirlineMembers = async (vaId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<VirtualAirlineMemberResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${vaId}/members`,

--- a/src/api/getVirtualAirlineRoles.ts
+++ b/src/api/getVirtualAirlineRoles.ts
@@ -3,7 +3,7 @@ import onAirRequest, { VirtualAirlineVARoleResponse } from './onAirRequest';
 
 const endPoint = 'va/';
 
-export const getVirtualAirlineRoles = async (vaId: string, apiKey: string, world: string) => {
+export const getVirtualAirlineRoles = async (vaId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<VirtualAirlineVARoleResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${vaId}/roles`,

--- a/src/api/getVirtualAirlineShareHolders.ts
+++ b/src/api/getVirtualAirlineShareHolders.ts
@@ -3,7 +3,7 @@ import onAirRequest, { VirtualAirlineShareHolderResponse } from './onAirRequest'
 
 const endPoint = 'va/';
 
-export const getVirtualAirlineShareHolders = async (vaId: string, apiKey: string, world: string) => {
+export const getVirtualAirlineShareHolders = async (vaId: string, apiKey: string) => {
     try {
         const response = await onAirRequest<VirtualAirlineShareHolderResponse>(
             `https://server1.onair.company/api/v1/${endPoint}${vaId}/shareholders`,

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -5,13 +5,12 @@ import { Aircraft, Airport, BalanceSheet, CashFlow, Company, Fbo, Flight, Income
 
 const apiKey: string | undefined = process.env.COMPANY_APIKEY;
 const companyId: string | undefined = process.env.COMPANY_ID;
-const world: string | undefined = process.env.COMPANY_WORLD;
 const vaId: string | undefined = process.env.VIRTUAL_AIRLINE_ID;
 
 describe('OnAirApi()', function() {
     it('when instantiated with valid data, it should return an OnAirApi object', async function() {
-        if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-            const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+        if (apiKey !== undefined && companyId !== undefined) {
+            const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
             expect(api).to.be.an('Object');
         }
@@ -19,8 +18,8 @@ describe('OnAirApi()', function() {
 
     describe('getAircraft()', function () {
         it('when getAircraft() is queried with valid data, it should return a Aircraft object', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
                 const aircraftId = 'd8a921a5-4774-4530-b75e-14b41545cabc';
 
                 const aircraft: Aircraft = await api.getAircraft(aircraftId);
@@ -33,8 +32,8 @@ describe('OnAirApi()', function() {
 
     describe('getAircraftFlights()', function () {
         it('when getAircraftFlights() is queried with valid data, it should return an Aircrafts flights array', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
                 const aircraftId = 'd8a921a5-4774-4530-b75e-14b41545cabc';
 
                 const flights: Flight[] = await api.getAircraftFlights(aircraftId);
@@ -47,8 +46,8 @@ describe('OnAirApi()', function() {
 
     describe('getAirport()', function() {
         it('when getAirport() is queried with valid data, it should return a valid Airport object', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
                 const airportCode = 'KLAX';
 
                 const airport: Airport = await api.getAirport(airportCode);
@@ -61,8 +60,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompanyFbos()', function() {
         it('when getCompanyFbos() is queried with valid data, it should return an Array of Fbo Objects', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const fbos: Fbo[] = await api.getCompanyFbos();
 
@@ -73,8 +72,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompanyFleet()', function() {
         it('when getCompanyFleet() is queried with valid data, it should return an Array of Aircraft Objects', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const aircraft: Aircraft[] = await api.getCompanyFleet();
 
@@ -85,8 +84,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompanyFlights()', function() {
         it('when getCompanyFlights() is queried with valid data, it should return an Array of Flight objects', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const flights: Flight[] = await api.getCompanyFlights();
 
@@ -97,8 +96,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompanyJobs()', function() {
         it('when getCompanyJobs() is queried with valid data, it should return an Array of pending Jobs', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const jobs: Job[] = await api.getCompanyJobs();
 
@@ -107,8 +106,8 @@ describe('OnAirApi()', function() {
         });
 
         it('when getCompanyJobs() is queried with valid data, passing true as the first argument, it should return an Array of completed Jobs', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const jobs: Job[] = await api.getCompanyJobs(true);
 
@@ -119,8 +118,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompanyEmployees()', function() {
         it('when getCompanyEmployees() is queried with valid data, it should return an Array of pending Jobs', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const employees: People[] = await api.getCompanyEmployees();
 
@@ -131,8 +130,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompanyCashFlow()', function() {
         it('when getCompanyCashFlow() is queried with valid data, it should return an object of the companie\'s cash flow.', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const cashflow: CashFlow = await api.getCompanyCashFlow();
 
@@ -143,8 +142,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompanyIncomeStatement()', function() {
         it('when queried providing a startDate and endDate, it should return an object of the company\'s income statement.', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const currentDate = new Date();
                 const currentDateStr = currentDate.toISOString();
@@ -159,8 +158,8 @@ describe('OnAirApi()', function() {
         });
 
         it('when queried without providing a startDate or an endDate, it should return an object of the company\'s current income statement within the last 30 days.', async function () {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const incomestatement: IncomeStatement = await api.getCompanyIncomeStatement();
 
@@ -171,8 +170,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompanyBalanceSheet()', function() {
         it('when getCompanyBalanceSheet() is queried with valid data, it should return an object of the company\'s current balance sheet.', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const balancesheet: BalanceSheet = await api.getCompanyBalanceSheet();
 
@@ -183,8 +182,8 @@ describe('OnAirApi()', function() {
 
     describe('getCompany()', function() {
         it('when getCompany() is queried with valid data, it should return a Company Object', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const company: Company = await api.getCompany();
 
@@ -195,8 +194,8 @@ describe('OnAirApi()', function() {
 
     describe('getFlight()', function() {
         it('when getFlight() is queried with valid data, it should return a Flight Object', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
                 const flightId = 'f0017707-825d-497f-b820-0404bb40132c';
 
                 const flight: Flight = await api.getFlight(flightId);
@@ -209,8 +208,8 @@ describe('OnAirApi()', function() {
 
     describe('getVirtualAirlineMembers()', function() {
         it('when getVirtualAirlineMembers() is queried with valid data, it should return an Array of Members in a VirtualAirline', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const members: Member[] = await api.getVirtualAirlineMembers();
 
@@ -221,8 +220,8 @@ describe('OnAirApi()', function() {
 
     describe('getVirtualAirline()', function() {
         it('when getVirtualAirline() is queried with valid data, it should return a VirtualAirline Object', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const va: VirtualAirline = await api.getVirtualAirline();
 
@@ -233,8 +232,8 @@ describe('OnAirApi()', function() {
 
     describe('getVirtualAirlineShareHolders()', function() {
         it('when getVirtualAirlineShareHolders() is queried with valid data, it should return a ShareHolder Array', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const shareholders: ShareHolder[] = await api.getVirtualAirlineShareHolders();
 
@@ -245,8 +244,8 @@ describe('OnAirApi()', function() {
 
     describe('getVirtualAirlineRoles()', function() {
         it('when getVirtualAirlineRoles() is queried with valid data, it should return a ShareHolder Array', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
 
                 const varoles: VARole[] = await api.getVirtualAirlineRoles();
 
@@ -257,8 +256,8 @@ describe('OnAirApi()', function() {
 
     describe('getEmployee()', function () {
         it('when getEmployee() is queried with valid data, it should return an employees details within a People object', async function() {
-            if (apiKey !== undefined && companyId !== undefined && world !== undefined) {
-                const api: OnAirApi = new OnAirApi({ apiKey, world, companyId, vaId });
+            if (apiKey !== undefined && companyId !== undefined) {
+                const api: OnAirApi = new OnAirApi({ apiKey, companyId, vaId });
                 const personId = '596b6c2e-4ac7-44e9-b1d4-a4299030cb04';
 
                 const employee: People = await api.getEmployee(personId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ export * from './types';
 export default class OnAirApi {
     // Properties
     private ApiKey: string
-    private World: string
     private CompanyId: string | undefined
     private VaId: string | undefined
 
@@ -30,59 +29,56 @@ export default class OnAirApi {
     constructor(config: OnAirApiConfig) {
         const {
             apiKey,
-            world,
             companyId,
             vaId
         } = config;
 
         if (!apiKey) throw new Error('No API Key provided');
-        if (!world) throw new Error('No World provided');
 
         this.ApiKey = apiKey;
         this.CompanyId = companyId;
-        this.World = world;
         this.VaId = vaId;
     }
 
     public async getCompany(): Promise<Company> {
         if (!this.CompanyId) throw new Error('No Company ID provided');
 
-        const company: Company = await Api.getCompany(this.CompanyId, this.ApiKey, this.World);
+        const company: Company = await Api.getCompany(this.CompanyId, this.ApiKey);
         return company;
     }
 
     public async getCompanyFleet(): Promise<Aircraft[]> {
         if (!this.CompanyId) throw new Error('No Company ID provided');
 
-        const companyFleet: Aircraft[] = await Api.getCompanyFleet(this.CompanyId, this.ApiKey, this.World);
+        const companyFleet: Aircraft[] = await Api.getCompanyFleet(this.CompanyId, this.ApiKey);
         return companyFleet;
     }
 
     public async getCompanyFbos(): Promise<Fbo[]> {
         if (!this.CompanyId) throw new Error('No Company ID provided');
 
-        const companyFbos: Fbo[] = await Api.getCompanyFbos(this.CompanyId, this.ApiKey, this.World);
+        const companyFbos: Fbo[] = await Api.getCompanyFbos(this.CompanyId, this.ApiKey);
         return companyFbos;
     }
 
     public async getCompanyFlights(page = 1, limit = 20): Promise<Flight[]> {
         if (!this.CompanyId) throw new Error('No Company ID provided');
 
-        const companyFlights: Flight[] = await Api.getCompanyFlights(this.CompanyId, this.ApiKey, this.World, page, limit);
+        const companyFlights: Flight[] = await Api.getCompanyFlights(this.CompanyId, this.ApiKey, page, limit);
         return companyFlights;
     }
 
     public async getCompanyJobs(completed = false): Promise<Job[]> {
         if (!this.CompanyId) throw new Error('No Company ID provided');
 
-        const companyJobs: Job[] = await Api.getCompanyJobs(this.CompanyId, this.ApiKey, this.World, completed);
+        const companyJobs: Job[] = await Api.getCompanyJobs(this.CompanyId, this.ApiKey, completed);
         return companyJobs;
     }
 
     public async getCompanyEmployees(): Promise<People[]> {
         if (!this.CompanyId) throw new Error('No Company ID provided');
 
-        const companyEmployees: People[] = await Api.getCompanyEmployees(this.CompanyId, this.ApiKey, this.World);
+        const companyEmployees: People[] = await Api.getCompanyEmployees(this.CompanyId, this.ApiKey);
 
         return companyEmployees;
     }
@@ -90,7 +86,7 @@ export default class OnAirApi {
     public async getCompanyCashFlow(): Promise<CashFlow> {
         if (!this.CompanyId) throw new Error('No Company ID provided');
 
-        const cashFlow: CashFlow = await Api.getCompanyCashFlow(this.CompanyId, this.ApiKey, this.World);
+        const cashFlow: CashFlow = await Api.getCompanyCashFlow(this.CompanyId, this.ApiKey);
 
         return cashFlow;
     }
@@ -108,7 +104,7 @@ export default class OnAirApi {
             endDate = new Date().toISOString();
         }
 
-        const incomeStatement: IncomeStatement = await Api.getCompanyIncomeStatement(startDate, endDate, this.CompanyId, this.ApiKey, this.World);
+        const incomeStatement: IncomeStatement = await Api.getCompanyIncomeStatement(startDate, endDate, this.CompanyId, this.ApiKey);
 
         return incomeStatement;
     }
@@ -116,7 +112,7 @@ export default class OnAirApi {
     public async getCompanyBalanceSheet(): Promise<BalanceSheet> {
         if (!this.CompanyId) throw new Error('No Company ID provided');
 
-        const balanceSheet: BalanceSheet = await Api.getCompanyBalanceSheet(this.CompanyId, this.ApiKey, this.World);
+        const balanceSheet: BalanceSheet = await Api.getCompanyBalanceSheet(this.CompanyId, this.ApiKey);
 
         return balanceSheet;
     }
@@ -124,63 +120,63 @@ export default class OnAirApi {
     public async getAircraft(aircraftId: string): Promise<Aircraft> {
         if (!aircraftId) throw new Error('Aircraft ID not provided');
 
-        const aircraft: Aircraft = await Api.getAircraft(aircraftId, this.ApiKey, this.World);
+        const aircraft: Aircraft = await Api.getAircraft(aircraftId, this.ApiKey);
         return aircraft;
     }
 
     public async getAircraftFlights(aircraftId: string, page = 1, limit = 20): Promise<Flight[]> {
         if (!aircraftId) throw new Error('Aircraft ID not provided');
 
-        const flights: Flight[] = await Api.getAircraftFlights(aircraftId, this.ApiKey, this.World, page, limit);
+        const flights: Flight[] = await Api.getAircraftFlights(aircraftId, this.ApiKey, page, limit);
         return flights;
     }
 
     public async getAirport(airportCode: string): Promise<Airport> {
         if (!airportCode) throw new Error('Airport ICAO code not provided');
 
-        const airport: Airport = await Api.getAirport(airportCode, this.ApiKey, this.World);
+        const airport: Airport = await Api.getAirport(airportCode, this.ApiKey);
         return airport;
     }
 
     public async getFlight(flightId: string): Promise<Flight> {
         if (!flightId) throw new Error('Flight ID not provided');
 
-        const flight: Flight = await Api.getFlight(flightId, this.ApiKey, this.World);
+        const flight: Flight = await Api.getFlight(flightId, this.ApiKey);
         return flight;
     }
 
     public async getVirtualAirline(): Promise<VirtualAirline> {
         if (!this.VaId) throw new Error('VA ID is not provided');
 
-        const virtualAirline: VirtualAirline = await Api.getVirtualAirline(this.VaId, this.ApiKey, this.World);
+        const virtualAirline: VirtualAirline = await Api.getVirtualAirline(this.VaId, this.ApiKey);
         return virtualAirline;
     }
 
     public async getVirtualAirlineMembers(): Promise<Member[]> {
         if (!this.VaId) throw new Error('VA ID is not provided');
 
-        const members: Member[] = await Api.getVirtualAirlineMembers(this.VaId, this.ApiKey, this.World);
+        const members: Member[] = await Api.getVirtualAirlineMembers(this.VaId, this.ApiKey);
         return members;
     }
 
     public async getVirtualAirlineShareHolders(): Promise<ShareHolder[]> {
         if (!this.VaId) throw new Error('VA ID is not provided');
 
-        const shareholders: ShareHolder[] = await Api.getVirtualAirlineShareHolders(this.VaId, this.ApiKey, this.World);
+        const shareholders: ShareHolder[] = await Api.getVirtualAirlineShareHolders(this.VaId, this.ApiKey);
         return shareholders;
     }
 
     public async getVirtualAirlineRoles(): Promise<VARole[]> {
         if (!this.VaId) throw new Error('VA ID is not provided');
 
-        const varoles: VARole[] = await Api.getVirtualAirlineRoles(this.VaId, this.ApiKey, this.World);
+        const varoles: VARole[] = await Api.getVirtualAirlineRoles(this.VaId, this.ApiKey);
         return varoles;
     }
 
     public async getEmployee(employeeId: string): Promise<People> {
         if (!employeeId) throw new Error('Employee ID is not provided');
 
-        const employee: People = await Api.getEmployee(employeeId, this.ApiKey, this.World);
+        const employee: People = await Api.getEmployee(employeeId, this.ApiKey);
         return employee;
     }
 }

--- a/src/types/Api.ts
+++ b/src/types/Api.ts
@@ -24,7 +24,6 @@ export interface Api {
 
 export interface OnAirApiConfig {
     apiKey: string,
-    world: string,
     companyId?: string | undefined,
     vaId?: string | undefined,
 }


### PR DESCRIPTION
Now that OnAir has migrated all of the worlds onto the same server, the OnAir Api now uses the same baseUrl (`https://server1.onair.company/api/v1/`) for all worlds. This means that the `world` parameter is no longer used within the Api to differentiate companies between the various worlds.